### PR TITLE
Add index to key

### DIFF
--- a/database/migrations/2019_01_15_160652_create_settings_table.php
+++ b/database/migrations/2019_01_15_160652_create_settings_table.php
@@ -14,7 +14,7 @@ class CreateSettingsTable extends Migration
     public function up()
     {
         Schema::create('settings', function (Blueprint $table) {
-            $table->string('key');
+            $table->string('key')->index();
             $table->string('value')->nullable();
             $table->string('locale')->nullable();
         });


### PR DESCRIPTION
Because it will be doing a lot of where statements on the `key` column an index is a good addition to improve performance, speed and reduces load for your database.